### PR TITLE
Use the native git repo instead of a pkg manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 coverage/
 logs/
 package-lock.json
+nc/

--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,8 @@ package: clean-release node_modules test lint codestyle
 
 .PHONY: publish
 publish: package
-	@curl --fail -H "X-JFrog-Art-Api:AKCp2WXCUb9AhGSoNXY4pnYJhfsJXG5T1KD2ebeLsiWQomi93w4URnDKMfBjtTb3iQsgnAMRn" -X PUT -T $(STAGE) $(PUBLISH_URL)
-	@echo
-	@echo Published $(PUBLISH_URL)
+	# TODO
+	@echo Not implemented
 
 .PHONY: test
 test: node_modules $(ALL_FILES)
@@ -143,7 +142,7 @@ clean-coverage:
 
 .PHONY: clean
 clean: clean-coverage
-	@rm -rf $(NODE_MODULES)
+	@rm -rf $(NODE_MODULES) nc
 
 
 #

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,23 +1,22 @@
 {
-  "targets": [
+  'targets': [
   {
-    "target_name": "atlas",
-      "dependencies": ["libatlas"],
-      "sources": [ "src/atlas.cc", "src/utils.cc",
-        "src/start_stop.cc", "src/functions.cc"],
-      "cflags": [ "-std=c++11", "-Wall", "-g", "-Os" ],
-      "libraries": [
-        "-L<(module_root_dir)/build/Release/",
+    'target_name': 'atlas',
+      'dependencies': ['libatlas'],
+      'sources': ["<!@(ls -1 src/*.cc)"],
+      'cflags': [ '-std=c++11', '-Wall', '-g', '-O2' ],
+      'libraries': [ 
+         "-L<(module_root_dir)/build/Release/",
         "-Wl,-rpath,\$$ORIGIN",
         "-latlasclient"
       ],
-      "include_dirs" : [
+      'include_dirs' : [
         "<!(node -e \"require('nan')\")",
-        "/usr/local/include"
+        'nc/root/include'
         ],
-      "conditions": [
+      'conditions': [
         [ 'OS=="mac"', {
-          "xcode_settings": {
+          'xcode_settings': {
             'OTHER_CPLUSPLUSFLAGS' : ['-std=c++11','-stdlib=libc++', '-v'],
             'OTHER_LDFLAGS': ['-stdlib=libc++'], 
             'MACOSX_DEPLOYMENT_TARGET': '10.12',
@@ -26,13 +25,13 @@
         }]]
   },
   {
-    "target_name": "libatlas",
-    "type": "none",
-    "actions": [{
-      "action_name": "install_libatlasclient",
-      "inputs": [""],
-      "outputs": [""],
-      "action": ["sh", "scripts/install-lib.sh"]
+    'target_name': 'libatlas',
+    'type': 'none',
+    'actions': [{
+      'action_name': 'install_libatlasclient',
+      'inputs': [''],
+      'outputs': [''],
+      'action': ['sh', 'scripts/install-lib.sh']
     }]
   },
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlasclient",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {
@@ -36,7 +36,7 @@
     "module_name": "atlas",
     "module_path": "./build/Release/",
     "remote_path": "atlas-native-client/v{version}/{configuration}/",
-    "host": "https://artifacts.netflix.com"
+    "host": "https://atlasclient.us-east-1.iepprod.netflix.net.s3-us-east-1.amazonaws.com"
   },
   "dependencies": {
     "node-pre-gyp": "0.6.x",

--- a/scripts/install-lib.sh
+++ b/scripts/install-lib.sh
@@ -1,40 +1,21 @@
 #!/bin/bash
 
-OS=$(uname -s)
-if [ "$OS" = "Linux" ]; then
-  # see if package already installed
-  V=$(dpkg -l libatlasclient | awk '/^ii/{print $3}')
-  case $V in
-    2.2.* )
-      # assume the rest of the dependencies have been installed
-      echo libatlasclient already installed: $V
-      ;;
-    * )
-      # same package name, but the xenial ami doesn't ship g++
-      ubuntu=$(lsb_release -c -s)
-      if [ ! -r /etc/apt/sources.list.d/nflx-$ubuntu.list ]; then
-        echo "deb     [arch=amd64] http://repo.test.netflix.net:7001/artifactory/debian-local $ubuntu main" | sudo tee /etc/apt/sources.list.d/nflx-$ubuntu.list
-      fi
-      sudo apt-get update
-      sudo apt-get install -y --allow-unauthenticated libatlasclient g++ 
-      ;;
-  esac
-  mkdir -p build/Release
-  rm -f build/Release/libatlasclient.dylib
-  cp /usr/local/lib/libatlasclient.so build/Release/
-elif [ "$OS" = "Darwin" ]; then
-  brew tap | grep -q homebrew/nflx || brew tap homebrew/nflx https://stash.corp.netflix.com/scm/brew/nflx.git
-  if brew ls --versions nflx-atlas-client | grep -q "2\.2" ; then
-    echo nflx-atlas-client already installed: $(brew ls --versions nflx-atlas-client)
-  else
-    brew update
-    if brew ls --versions nflx-atlas-client >/dev/null 2>/dev/null; then
-      brew upgrade nflx-atlas-client || true
-    else
-      brew install nflx-atlas-client
-    fi
-  fi
-  mkdir -p build/Release
-  rm -f build/Release/libatlasclient.dylib
-  cp /usr/local/lib/libatlasclient.dylib build/Release/
+if [ -d nc/root/usr/local/include/atlas/atlas_client.h ]; then
+  echo Already installed
+  exit 0
 fi
+
+#NATIVE_CLIENT_VERSION=${1:-v2.2.0}
+#rm -rf nc
+#mkdir nc
+cd nc
+#git init 
+#git remote add origin https://github.com/Netflix-Skunkworks/atlas-native-client.git
+#git fetch origin $NATIVE_CLIENT_VERSION
+#git reset --hard FETCH_HEAD
+#mkdir build root
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=/ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+make
+make install DESTDIR=../root
+cp ../root/lib/libatlas* ../../build/Release


### PR DESCRIPTION
We used to rely on a package manager (`apt-get` or `brew`) to install
our `libatlasclient` dependency. The main problem with this approach
is the fact that those package managers will install the latest
available artifact, as opposed to the one used when we tested and built
this module. Now we just fetch a particular tagged release from github
and go from there.