### PR TITLE
Use the native git repo instead of a pkg manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 coverage/
 logs/
 package-lock.json
+nc/

--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,8 @@ package: clean-release node_modules test lint codestyle
 
 .PHONY: publish
 publish: package
-	@curl --fail -H "X-JFrog-Art-Api:AKCp2WXCUb9AhGSoNXY4pnYJhfsJXG5T1KD2ebeLsiWQomi93w4URnDKMfBjtTb3iQsgnAMRn" -X PUT -T $(STAGE) $(PUBLISH_URL)
-	@echo
-	@echo Published $(PUBLISH_URL)
+	# TODO
+	@echo Not implemented
 
 .PHONY: test
 test: node_modules $(ALL_FILES)
@@ -143,7 +142,7 @@ clean-coverage:
 
 .PHONY: clean
 clean: clean-coverage
-	@rm -rf $(NODE_MODULES)
+	@rm -rf $(NODE_MODULES) nc
 
 
 #

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,23 +1,22 @@
 {
-  "targets": [
+  'targets': [
   {
-    "target_name": "atlas",
-      "dependencies": ["libatlas"],
-      "sources": [ "src/atlas.cc", "src/utils.cc",
-        "src/start_stop.cc", "src/functions.cc"],
-      "cflags": [ "-std=c++11", "-Wall", "-g", "-Os" ],
-      "libraries": [
-        "-L<(module_root_dir)/build/Release/",
+    'target_name': 'atlas',
+      'dependencies': ['libatlas'],
+      'sources': ["<!@(ls -1 src/*.cc)"],
+      'cflags': [ '-std=c++11', '-Wall', '-g', '-O2' ],
+      'libraries': [ 
+         "-L<(module_root_dir)/build/Release/",
         "-Wl,-rpath,\$$ORIGIN",
         "-latlasclient"
       ],
-      "include_dirs" : [
+      'include_dirs' : [
         "<!(node -e \"require('nan')\")",
-        "/usr/local/include"
+        'nc/root/include'
         ],
-      "conditions": [
+      'conditions': [
         [ 'OS=="mac"', {
-          "xcode_settings": {
+          'xcode_settings': {
             'OTHER_CPLUSPLUSFLAGS' : ['-std=c++11','-stdlib=libc++', '-v'],
             'OTHER_LDFLAGS': ['-stdlib=libc++'], 
             'MACOSX_DEPLOYMENT_TARGET': '10.12',
@@ -26,13 +25,13 @@
         }]]
   },
   {
-    "target_name": "libatlas",
-    "type": "none",
-    "actions": [{
-      "action_name": "install_libatlasclient",
-      "inputs": [""],
-      "outputs": [""],
-      "action": ["sh", "scripts/install-lib.sh"]
+    'target_name': 'libatlas',
+    'type': 'none',
+    'actions': [{
+      'action_name': 'install_libatlasclient',
+      'inputs': [''],
+      'outputs': [''],
+      'action': ['sh', 'scripts/install-lib.sh']
     }]
   },
   ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -31,7 +31,7 @@
       'action_name': 'install_libatlasclient',
       'inputs': [''],
       'outputs': [''],
-      'action': ['sh', 'scripts/install-lib.sh']
+      'action': ['node', 'scripts/install-lib.js']
     }]
   },
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "atlasclient",
   "version": "1.15.0",
+  "native_version": "v2.2.0",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlasclient",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {
@@ -36,7 +36,7 @@
     "module_name": "atlas",
     "module_path": "./build/Release/",
     "remote_path": "atlas-native-client/v{version}/{configuration}/",
-    "host": "https://artifacts.netflix.com"
+    "host": "https://atlasclient.us-east-1.iepprod.netflix.net.s3-us-east-1.amazonaws.com"
   },
   "dependencies": {
     "node-pre-gyp": "0.6.x",

--- a/scripts/install-lib-from-gh.sh
+++ b/scripts/install-lib-from-gh.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
+set -e
+
 if [ -d nc/root/usr/local/include/atlas/atlas_client.h ]; then
   echo Already installed
   exit 0
 fi
 
-NATIVE_CLIENT_VERSION=${1:-v2.2.0}
+if [ $# = 0 ] ; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
 rm -rf nc
 mkdir nc
 cd nc

--- a/scripts/install-lib.js
+++ b/scripts/install-lib.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const exec = require('child_process').exec;
+const read = require('fs').readFileSync;
+const pkgJson = JSON.parse(read('package.json'));
+const cmd = 'sh ./scripts/install-lib-from-gh.sh ' + pkgJson.native_version;
+
+const child = exec(cmd);
+child.stdout.on('data', function(data) {
+  process.stdout.write(data);
+});
+
+child.stderr.on('data', function(data) {
+  process.stderr.write('\x1b[31m' + data + '\x1b[0m');
+});
+
+
+


### PR DESCRIPTION
We used to rely on a package manager (`apt-get` or `brew`) to install
our `libatlasclient` dependency. The main problem with this approach
is the fact that those package managers will install the latest
available artifact, as opposed to the one used when we tested and built
this module. Now we just fetch a particular tagged release from github
and go from there.