### PR TITLE
Update to the latest libatlasclient API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlasclient",
-  "version": "1.15.0",
-  "native_version": "v2.2.0",
+  "version": "1.16.0",
+  "native_version": "v3.0.0",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {

--- a/src/functions.cc
+++ b/src/functions.cc
@@ -26,8 +26,8 @@ NAN_METHOD(measurements) {
     auto tags = Nan::New<Object>();
     const auto& t = m.tags;
     for (const auto& kv : t) {
-      tags->Set(Nan::New(kv.first.c_str()).ToLocalChecked(),
-                Nan::New(kv.second.c_str()).ToLocalChecked());
+      tags->Set(Nan::New(kv.first.get()).ToLocalChecked(),
+                Nan::New(kv.second.get()).ToLocalChecked());
     }
     measurement->Set(Nan::New("tags").ToLocalChecked(), tags);
     measurement->Set(Nan::New("value").ToLocalChecked(), Nan::New(m.value));
@@ -68,8 +68,8 @@ NAN_METHOD(config) {
   ret->Set(Nan::New("publishConfig").ToLocalChecked(), pubCfg);
   auto commonTags = Nan::New<Object>();
   for (const auto& kv : currentCfg.CommonTags()) {
-    commonTags->Set(Nan::New(kv.first.c_str()).ToLocalChecked(),
-                    Nan::New(kv.second.c_str()).ToLocalChecked());
+    commonTags->Set(Nan::New(kv.first.get()).ToLocalChecked(),
+                    Nan::New(kv.second.get()).ToLocalChecked());
   }
   ret->Set(Nan::New("commonTags").ToLocalChecked(), commonTags);
   ret->Set(Nan::New("loggingDirectory").ToLocalChecked(),

--- a/src/start_stop.cc
+++ b/src/start_stop.cc
@@ -94,13 +94,13 @@ static void create_memory_meters() {
 static void create_gc_timers() {
   auto base_id = node_id("nodejs.gc.pause");
   gc_timers[v8::kGCTypeScavenge] =
-      atlas_registry.timer(base_id->WithTag(Tag{"id", "scavenge"}));
+      atlas_registry.timer(base_id->WithTag(Tag::of("id", "scavenge")));
   gc_timers[v8::kGCTypeMarkSweepCompact] =
-      atlas_registry.timer(base_id->WithTag(Tag{"id", "markSweepCompact"}));
+      atlas_registry.timer(base_id->WithTag(Tag::of("id", "markSweepCompact")));
   gc_timers[v8::kGCTypeIncrementalMarking] =
-      atlas_registry.timer(base_id->WithTag(Tag{"id", "incrementalMarking"}));
+      atlas_registry.timer(base_id->WithTag(Tag::of("id", "incrementalMarking")));
   gc_timers[v8::kGCTypeProcessWeakCallbacks] =
-      atlas_registry.timer(base_id->WithTag(Tag{"id", "processWeakCallbacks"}));
+      atlas_registry.timer(base_id->WithTag(Tag::of("id", "processWeakCallbacks")));
 }
 
 static std::shared_ptr<Timer> get_gc_timer(GCType type) {
@@ -112,7 +112,7 @@ static std::shared_ptr<Timer> get_gc_timer(GCType type) {
 
   // Unknown GC type - should never happen with node 6.x or 7.x
   return atlas_registry.timer(
-      node_id("nodejs.gc.pause")->WithTag(Tag{"id", std::to_string(int_type)}));
+      node_id("nodejs.gc.pause")->WithTag(Tag::of("id", std::to_string(int_type))));
 }
 
 inline size_t number_heap_spaces() {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -24,7 +24,7 @@ bool tagsFromObject(v8::Isolate* isolate, const v8::Local<v8::Object>& object,
                        "' when specifying tags";
         Nan::ThrowError(err_msg.c_str());
       }
-      (*tags)[k] = v;
+      tags->add(k.c_str(), v.c_str());
     }
     return true;
   } else {


### PR DESCRIPTION
This makes use of the 3.x version of libatlasclient, which makes
significant memory utilization improvements.