### PR TITLE
Travis setup for node-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ node_js:
 os:
   - "osx"
   - "linux"
+
+osx_image: xcode9.1
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "6"
+  - "7"
+  - "8"
+os:
+  - "osx"
+  - "linux"


### PR DESCRIPTION
Travis setup for the atlas-node-client

Builds for linux and osx, node versions 6, 7, 8.