### PR TITLE
Fix negative promotion rate values

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,6 @@
     'target_name': 'atlas',
       'dependencies': ['libatlas'],
       'sources': ["<!@(ls -1 src/*.cc)"],
-      'cflags': [ '-std=c++11', '-Wall', '-g', '-O2' ],
       'libraries': [ 
          "-L<(module_root_dir)/build/Release/",
         "-Wl,-rpath,\$$ORIGIN",
@@ -17,12 +16,16 @@
       'conditions': [
         [ 'OS=="mac"', {
           'xcode_settings': {
-            'OTHER_CPLUSPLUSFLAGS' : ['-std=c++11','-stdlib=libc++', '-v'],
+            'OTHER_CPLUSPLUSFLAGS' : ['-stdlib=libc++', '-v', '-std=c++11', '-Wall', '-Wextra', '-Wno-unused-parameter', '-g', '-O2' ],
             'OTHER_LDFLAGS': ['-stdlib=libc++'], 
             'MACOSX_DEPLOYMENT_TARGET': '10.12',
             'GCC_ENABLE_CPP_EXCEPTIONS': 'NO'
           }
-        }]]
+        }],
+        ['OS=="linux"', {
+          'cflags': ['-std=c++11', '-Wall', '-Wextra', '-Wno-unused-parameter', '-g', '-O2' ]
+        }]
+      ]
   },
   {
     'target_name': 'libatlas',
@@ -36,3 +39,4 @@
   },
   ]
 }
+

--- a/scripts/install-lib-from-gh.sh
+++ b/scripts/install-lib-from-gh.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 set -e
-
-if [ -d nc/root/usr/local/include/atlas/atlas_client.h ]; then
+if [ -r nc/root/include/atlas/atlas_client.h ]; then
   echo Already installed
   exit 0
 fi
@@ -22,6 +21,6 @@ git reset --hard FETCH_HEAD
 mkdir build root
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=/ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-make
+make -j2
 make install DESTDIR=../root
 cp ../root/lib/libatlas* ../../build/Release


### PR DESCRIPTION
`nodejs.gc.promotionRate` showed negative values. This was caused
because `delta` was of an unsigned type, and therefore the check
`delta > 0` was also including negative values. Fix by being explicit
about the types for readability and making delta a signed type.

We also add more warnings to the default flags used for compiling, which
hopefully will catch similar errors, but unfortunately in this case the
check `unsigned_var > 0` wasn't always true so no warnings would have
triggered.