### PR TITLE
Increase the threshold for the event loop test

### DIFF
--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -7,7 +7,7 @@ const assert = chai.assert;
 describe('metrics', () => {
   it('should measure event loop tick', (done) => {
     var ms = 50;
-    var threshold = 1e6; // value is within 1ms
+    var threshold = 10e6; // value is within 10ms
     var fakeSelf = {
       eventLoopTime: {
         record: (time) => {


### PR DESCRIPTION
The test currently assumes that the node vm will be scheduled to run
within 1ms, which is too optimistic in many scenarios. This makes it a
bit less flakey by increasing the value to 10ms.