### PR TITLE
Update to native client 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlasclient",
-  "version": "1.18.2",
-  "native_version": "v3.6.2",
+  "version": "1.19.0",
+  "native_version": "v3.7.0",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {

--- a/scripts/install-lib-from-gh.sh
+++ b/scripts/install-lib-from-gh.sh
@@ -11,6 +11,7 @@ if [ $# = 0 ] ; then
   echo "Usage: $0 <version>" >&2
   exit 1
 fi
+NATIVE_CLIENT_VERSION=$1
 
 rm -rf nc
 mkdir nc
@@ -22,8 +23,7 @@ git reset --hard FETCH_HEAD
 mkdir build root
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=/ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-make -j2
+make -j8 
 make install DESTDIR=../root
+rm -f ../root/lib/libatlas*a
 cp ../root/lib/libatlas* ../../build/Release
-# remove unused static artifacts (created on linux)
-rm -f ../../build/Release/*.a

--- a/src/functions.cc
+++ b/src/functions.cc
@@ -16,7 +16,7 @@ using v8::Maybe;
 using v8::Object;
 
 NAN_METHOD(measurements) {
-  const auto& config = GetConfig();
+  auto config = atlas::GetConfig();
   auto common_tags = config.CommonTags();
   const auto& measurements = atlas_registry.GetMainMeasurements(config, common_tags);
 
@@ -39,26 +39,29 @@ NAN_METHOD(measurements) {
 }
 
 NAN_METHOD(config) {
-  auto currentCfg = GetConfig();
+  auto currentCfg = atlas::GetConfig();
+  const auto& endpoints = currentCfg.EndpointConfiguration();
+  const auto& log = currentCfg.LogConfiguration();
+  const auto& http = currentCfg.HttpConfiguration();
   auto ret = Nan::New<Object>();
   ret->Set(Nan::New("evaluateUrl").ToLocalChecked(),
-           Nan::New(currentCfg.EvalEndpoint().c_str()).ToLocalChecked());
+           Nan::New(endpoints.evaluate.c_str()).ToLocalChecked());
   ret->Set(Nan::New("subscriptionsUrl").ToLocalChecked(),
-           Nan::New(currentCfg.SubsEndpoint().c_str()).ToLocalChecked());
+           Nan::New(endpoints.subscriptions.c_str()).ToLocalChecked());
   ret->Set(Nan::New("publishUrl").ToLocalChecked(),
-           Nan::New(currentCfg.PublishEndpoint().c_str()).ToLocalChecked());
+           Nan::New(endpoints.publish.c_str()).ToLocalChecked());
   ret->Set(Nan::New("subscriptionsRefreshMillis").ToLocalChecked(),
            Nan::New(static_cast<double>(currentCfg.SubRefreshMillis())));
   ret->Set(Nan::New("batchSize").ToLocalChecked(),
-           Nan::New(currentCfg.BatchSize()));
+           Nan::New(http.batch_size));
   ret->Set(Nan::New("connectTimeout").ToLocalChecked(),
-           Nan::New(currentCfg.ConnectTimeout()));
+           Nan::New(http.connect_timeout));
   ret->Set(Nan::New("readTimeout").ToLocalChecked(),
-           Nan::New(currentCfg.ReadTimeout()));
+           Nan::New(http.read_timeout));
   ret->Set(Nan::New("dumpMetrics").ToLocalChecked(),
-           Nan::New(currentCfg.ShouldDumpMetrics()));
+           Nan::New(log.dump_metrics));
   ret->Set(Nan::New("dumpSubscriptions").ToLocalChecked(),
-           Nan::New(currentCfg.ShouldDumpSubs()));
+           Nan::New(log.dump_subscriptions));
   ret->Set(Nan::New("publishEnabled").ToLocalChecked(),
            Nan::New(currentCfg.IsMainEnabled()));
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -179,7 +179,7 @@ describe('atlas extension', () => {
     bt.record(1, 200000);
     assert.equal(t.count(), 2);
     bt.record(0, 212 * 1000);
-    let t2 = atlas.counter('example.bucket.t', {
+    let t2 = atlas.timer('example.bucket.t', {
       bucket: '0375ms'
     });
     assert.equal(t2.count(), 1);


### PR DESCRIPTION
Update to atlas native client v3.7.0 which uses the new config API.

For some reason one of the bucket timer test cases was failing, and it
was due to the test case being broken. It was getting a counter
with certain tags, and not a timer, which is what gets generated by
bucket timers. In a future PR we will have to address what happens when
the user asks for a meter with the same ID but a different type to one
already registered.