### PR TITLE
Add support for double counters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,29 @@
+## 1.20.0 (2018-03-05)
+
+#### New
+
+* libatlasclient (v3.7.2) exposes dcounter. A counter that takes floating point increments
+
+## 1.19.2 (2013-03-02)
+
+#### Fix
+
+* Removes unneeded artifacts from binary blob
+ 
+## 1.19.1 (2018-03-01)
+
+#### Update
+
+* libatlasclient (v3.7.1): fixes locking bugs around logging, and fixes some threading issues.
+
+## 1.19.0 (2018-02-28)
+
+#### Update
+* libatlasclient (v3.7.0): new config api
+
+#### Fix
+* Remove unneeded artifacts from build/Release directory to trim size of the module
+
 ## 1.18.2 (2017-11-22)
 
 #### Update

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ ifeq ($(SYSTEM), Darwin)
 	@echo Current path: ${CUR_PATH}
 	install_name_tool -change ${CUR_PATH} @loader_path/libatlasclient.dylib build/Release/atlas.node
 endif
+	rm -rf build/Release/obj.target build/Release/.deps
 
 node_modules: package.json build/Release
 	@$(NPM) install

--- a/index.js
+++ b/index.js
@@ -117,6 +117,8 @@ let scope = function(commonTags) {
     getDebugInfo: debugInfo,
     counter: (name, tags) => atlas.counter(
       name, Object.assign({}, commonTags, tags)),
+    dcounter: (name, tags) => atlas.dcounter(
+      name, Object.assign({}, commonTags, tags)),
     intervalCounter: (name, tags) => atlas.intervalCounter(
       name, Object.assign({}, commonTags, tags)),
     timer: (name, tags) => atlas.timer(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlasclient",
-  "version": "1.19.0",
-  "native_version": "v3.7.0",
+  "version": "1.20.0",
+  "native_version": "v3.7.2",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {

--- a/src/atlas.cc
+++ b/src/atlas.cc
@@ -19,6 +19,9 @@ NAN_MODULE_INIT(InitAll) {
   Set(target, New("counter").ToLocalChecked(),
       GetFunction(New<FunctionTemplate>(counter)).ToLocalChecked());
 
+  Set(target, New("dcounter").ToLocalChecked(),
+      GetFunction(New<FunctionTemplate>(dcounter)).ToLocalChecked());
+
   Set(target, New("intervalCounter").ToLocalChecked(),
       GetFunction(New<FunctionTemplate>(interval_counter)).ToLocalChecked());
 
@@ -63,6 +66,7 @@ NAN_MODULE_INIT(InitAll) {
       GetFunction(New<FunctionTemplate>(push)).ToLocalChecked());
 
   JsCounter::Init(target);
+  JsDCounter::Init(target);
   JsIntervalCounter::Init(target);
   JsTimer::Init(target);
   JsLongTaskTimer::Init(target);

--- a/src/functions.h
+++ b/src/functions.h
@@ -25,6 +25,9 @@ NAN_METHOD(push);
 // get a counter
 NAN_METHOD(counter);
 
+// get a double counter
+NAN_METHOD(dcounter);
+
 // get an interval counter
 NAN_METHOD(interval_counter);
 
@@ -75,6 +78,22 @@ class JsCounter : public Nan::ObjectWrap {
   std::shared_ptr<atlas::meter::Counter> counter_;
 };
 
+class JsDCounter : public Nan::ObjectWrap {
+ public:
+  static NAN_MODULE_INIT(Init);
+  static Nan::Persistent<v8::Function> constructor;
+
+ private:
+  explicit JsDCounter(atlas::meter::IdPtr id);
+
+  static NAN_METHOD(New);
+  static NAN_METHOD(Increment);
+  static NAN_METHOD(Add);
+  static NAN_METHOD(Count);
+
+  std::shared_ptr<atlas::meter::DCounter> counter_;
+};
+  
 // wrapper for a timer
 class JsTimer : public Nan::ObjectWrap {
  public:

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -25,6 +25,28 @@ describe('atlas extension', () => {
     counter.increment(2);
     assert.equal(counter.count(), 2);
   });
+  
+  it('should provide double counters', () => {
+    let counter = atlas.dcounter('fooDouble');
+    assert.equal(counter.increment(), undefined);
+    assert.equal(counter.count(), 1);
+    assert.equal(counter.add(.42), undefined);
+    assert.equal(counter.count(), 1.42);
+  });
+
+  it('should handle fractional increments', () => {
+    let ic = atlas.counter('int_counter');
+    let dc = atlas.dcounter('double_counter');
+    let counters = [ ic, dc ];
+    for (let counter of counters) {
+      counter.increment(0.3);
+      counter.increment(0.3);
+      counter.increment(0.3);
+      counter.increment(0.3);
+    }
+    assert.equal(ic.count(), 0);
+    assert.equal(dc.count(), 1.2);
+  });
 
   const NANOS = 1000 * 1000 * 1000;
   it('should provide timers', () => {


### PR DESCRIPTION
This adds support for the `dcounter` type introduced in atlasclient
3.7.2. A counter that supports floating point increments