### PR TITLE
Add a development mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 1.21.0 (2018-03-06)
+
+#### New
+
+* `atlas.setDevMode(true)` will enable metrics validation at creation time,
+  throwing errors in case of issues.
+
 ## 1.20.0 (2018-03-05)
 
 #### New

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ See the [test] directory for examples of unit testing.  These tests can be run w
 
 [test]: https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client/browse/test
 
+## Development Mode
+
+When developing it's sometimes useful to throw errors when constructing invalid
+metrics. By default the client will ignore these errors so it doesn't affect a
+running application in production, but you can change this behavior by enabling
+the development mode:
+
+`atlas.setDevMode(true);`
+
+This will validate metrics can be successfully sent to atlas, and throw in case of errors.
+
 ## Debugging
 
 * Configuration for the atlas-native-client, the dependency of the atlas-node-client that is responsible

--- a/index.js
+++ b/index.js
@@ -58,10 +58,17 @@ function startAtlas(config) {
     runtimeMetrics = cfg.runtimeMetrics;
   }
 
+  let developmentMode = false;
+
+  if ('developmentMode' in cfg) {
+    developmentMode = cfg.developmentMode;
+  }
+
   const nodeVersion = {
     'nodejs.version': process.version
   };
   atlas.start({
+    developmentMode: developmentMode,
     logDirs: logDirs,
     runtimeMetrics: runtimeMetrics,
     runtimeTags: nodeVersion
@@ -96,6 +103,10 @@ function debugInfo() {
   };
 }
 
+function devMode(enabled) {
+  atlas.setDevMode(enabled);
+}
+
 let scope = function(commonTags) {
   let bucketArgs = function(name) {
     let tags, bucketFunction;
@@ -114,6 +125,7 @@ let scope = function(commonTags) {
   let s = {
     start: startAtlas,
     stop: stopAtlas,
+    setDevMode: devMode,
     getDebugInfo: debugInfo,
     counter: (name, tags) => atlas.counter(
       name, Object.assign({}, commonTags, tags)),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlasclient",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "native_version": "v3.7.2",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",

--- a/src/atlas.cc
+++ b/src/atlas.cc
@@ -65,6 +65,9 @@ NAN_MODULE_INIT(InitAll) {
   Set(target, New("push").ToLocalChecked(),
       GetFunction(New<FunctionTemplate>(push)).ToLocalChecked());
 
+  Set(target, New("setDevMode").ToLocalChecked(),
+      GetFunction(New<FunctionTemplate>(set_dev_mode)).ToLocalChecked());
+
   JsCounter::Init(target);
   JsDCounter::Init(target);
   JsIntervalCounter::Init(target);

--- a/src/functions.cc
+++ b/src/functions.cc
@@ -15,10 +15,18 @@ using v8::Local;
 using v8::Maybe;
 using v8::Object;
 
+NAN_METHOD(set_dev_mode) {
+  if (info.Length() == 1 && info[0]->IsBoolean()) {
+    auto b = info[0]->BooleanValue();
+    dev_mode = b;
+  }
+}
+
 NAN_METHOD(measurements) {
   auto config = atlas::GetConfig();
   auto common_tags = config.CommonTags();
-  const auto& measurements = atlas_registry.GetMainMeasurements(config, common_tags);
+  const auto& measurements =
+      atlas_registry.GetMainMeasurements(config, common_tags);
 
   auto ret = Nan::New<v8::Array>();
 
@@ -52,8 +60,7 @@ NAN_METHOD(config) {
            Nan::New(endpoints.publish.c_str()).ToLocalChecked());
   ret->Set(Nan::New("subscriptionsRefreshMillis").ToLocalChecked(),
            Nan::New(static_cast<double>(currentCfg.SubRefreshMillis())));
-  ret->Set(Nan::New("batchSize").ToLocalChecked(),
-           Nan::New(http.batch_size));
+  ret->Set(Nan::New("batchSize").ToLocalChecked(), Nan::New(http.batch_size));
   ret->Set(Nan::New("connectTimeout").ToLocalChecked(),
            Nan::New(http.connect_timeout));
   ret->Set(Nan::New("readTimeout").ToLocalChecked(),

--- a/src/functions.h
+++ b/src/functions.h
@@ -13,6 +13,9 @@
 #include <atlas/meter/subscription_max_gauge.h>
 #include <nan.h>
 
+// enable/disable development mode
+NAN_METHOD(set_dev_mode);
+
 // get an array of measurements intended for the main publish pipeline
 NAN_METHOD(measurements);
 //
@@ -93,7 +96,7 @@ class JsDCounter : public Nan::ObjectWrap {
 
   std::shared_ptr<atlas::meter::DCounter> counter_;
 };
-  
+
 // wrapper for a timer
 class JsTimer : public Nan::ObjectWrap {
  public:

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1,8 +1,131 @@
 #include "utils.h"
 #include <atlas/atlas_client.h>
+#include <iostream>
+#include <sstream>
+#include <unordered_set>
 
 using atlas::meter::IdPtr;
 using atlas::meter::Tags;
+using atlas::util::StartsWith;
+using atlas::util::StrRef;
+using atlas::util::intern_str;
+
+bool dev_mode = false;
+
+static bool empty_or_null(StrRef r) { return r.is_null() || r.length() == 0; }
+
+static bool is_key_restricted(StrRef k) {
+  return StartsWith(k, "nf.") || StartsWith(k, "atlas.");
+}
+
+static std::unordered_set<StrRef> kValidNfTags = {
+    intern_str("nf.node"),          intern_str("nf.cluster"),
+    intern_str("nf.app"),           intern_str("nf.asg"),
+    intern_str("nf.stack"),         intern_str("nf.ami"),
+    intern_str("nf.vmtype"),        intern_str("nf.zone"),
+    intern_str("nf.region"),        intern_str("nf.account"),
+    intern_str("nf.country"),       intern_str("nf.task"),
+    intern_str("nf.country.rollup")};
+
+static auto kDsType = intern_str("atlas.dstype");
+static auto kLegacy = intern_str("atlas.legacy");
+static auto kNameRef = intern_str("name");
+
+static bool is_user_key_invalid(StrRef k) noexcept {
+  if (StartsWith(k, "atlas.")) {
+    return k != kDsType && k != kLegacy;
+  }
+
+  if (StartsWith(k, "nf.")) {
+    return kValidNfTags.find(k) == kValidNfTags.end();
+  }
+
+  return false;
+}
+
+static constexpr size_t MAX_KEY_LENGTH = 60;
+static constexpr size_t MAX_VAL_LENGTH = 120;
+static constexpr size_t MAX_USER_TAGS = 20;
+static constexpr size_t MAX_NAME_LENGTH = 255;
+static void throw_if_invalid(const std::string& name, const Tags& tags) {
+  std::ostringstream name_err;
+  auto invalid_name = false;
+  if (name.empty()) {
+    name_err << "Name is required, cannot be empty\n";
+    invalid_name = true;
+  } else if (name.length() > MAX_NAME_LENGTH) {
+    name_err << "Name '" << name
+             << "' exceeds length limits. Length=" << name.length() << " > "
+             << MAX_NAME_LENGTH << "\n";
+    invalid_name = true;
+  }
+
+  auto invalid_tags = false;
+  std::ostringstream tag_errors;
+  size_t user_tags = 0;
+  for (const auto& kv : tags) {
+    const auto& k_ref = kv.first;
+    const auto& v_ref = kv.second;
+
+    if (empty_or_null(k_ref) || empty_or_null(v_ref)) {
+      invalid_tags = true;
+      tag_errors << "A tag cannot have an empty key or value\n";
+      continue;
+    }
+
+    auto k_length = k_ref.length();
+    auto v_length = v_ref.length();
+    if (k_length > MAX_KEY_LENGTH || v_length > MAX_VAL_LENGTH) {
+      invalid_tags = true;
+      tag_errors << "Tag " << k_ref.get() << "=" << v_ref.get()
+                 << " exceeds length limits. ";
+      if (k_length > MAX_KEY_LENGTH) {
+        tag_errors << "Key length=" << k_length << " > " << MAX_KEY_LENGTH;
+      }
+      if (v_length > MAX_VAL_LENGTH) {
+        if (k_length > MAX_KEY_LENGTH) {
+          tag_errors << ", ";
+        }
+        tag_errors << "Value length=" << v_length << " > " << MAX_VAL_LENGTH;
+      }
+      tag_errors << '\n';
+    }
+
+    if (!is_key_restricted(k_ref)) {
+      ++user_tags;
+    }
+
+    if (is_user_key_invalid(k_ref)) {
+      invalid_tags = true;
+      tag_errors << "Tag key " << k_ref.get()
+                 << " is using a reserved namespace\n";
+    }
+  }
+
+  if (user_tags > MAX_USER_TAGS) {
+    invalid_tags = true;
+    tag_errors << "Too many user tags. There is a " << MAX_USER_TAGS
+               << " user tags limit. Detected user tags = " << user_tags
+               << '\n';
+  }
+
+  if (invalid_name || invalid_tags) {
+    std::string err_msg;
+    if (invalid_name) {
+      err_msg = name_err.str();
+    } else {
+      err_msg = "Metric with name='" + name + "' contains invalid tags\n";
+    }
+
+    if (invalid_tags) {
+      err_msg += tag_errors.str();
+    }
+
+    // remove the trailing newline
+    err_msg[err_msg.length() - 1] = '\0';
+    Nan::ThrowError(err_msg.c_str());
+  }
+}
 
 bool tagsFromObject(v8::Isolate* isolate, const v8::Local<v8::Object>& object,
                     Tags* tags) {
@@ -53,6 +176,10 @@ IdPtr idFromValue(const Nan::FunctionCallbackInfo<v8::Value>& info, int argc) {
           "Expected an object with string keys and string values as the second "
           "argument");
     }
+  }
+
+  if (dev_mode) {
+    throw_if_invalid(name, tags);
   }
   return atlas_registry.CreateId(name, tags);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -8,3 +8,5 @@ bool tagsFromObject(v8::Isolate* isolate, const v8::Local<v8::Object>& object,
 
 atlas::meter::IdPtr idFromValue(
     const Nan::FunctionCallbackInfo<v8::Value>& info, int argc);
+
+extern bool dev_mode;

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -302,4 +302,40 @@ describe('atlas extension', () => {
     };
     assert.throw(fn, /invalidKey/);
   });
+
+  it('should validate metrics when in dev mode', () => {
+    atlas.setDevMode(true);
+    const noName = () => {
+      atlas.counter('');
+    };
+    assert.throw(noName, /empty/);
+
+    const invalidTagKey = () => {
+      const tags = {};
+      tags['a'.repeat(70)] = 'v';
+      atlas.timer('foo', tags);
+    };
+    assert.throw(invalidTagKey, /exceeds length/);
+
+    const invalidTagVal = () => {
+      atlas.timer('foo', {k: 'a'.repeat(160)});
+    };
+    assert.throw(invalidTagVal, /exceeds length/);
+
+    const tooManyTags = () => {
+      const tags = {};
+
+      for (let i = 0; i < 22; ++i) {
+        tags[i] = 'v';
+      }
+      atlas.counter('f', tags);
+    };
+    assert.throw(tooManyTags, /user tags/);
+
+    const reserved = () => {
+      atlas.counter('foo', {'atlas.test': 'foo'});
+    };
+    assert.throw(reserved, /reserved namespace/);
+
+  });
 });


### PR DESCRIPTION
This adds a dev mode to make it easier to catch errors in metrics
production earlier. In the future we can extend this by modifying
logging, etc.