### PR TITLE
Make sure metrics always have a name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 1.21.1 (2018-03-09)
+
+#### Fix
+
+* Make sure metrics always have a valid name. 
+
 ## 1.21.0 (2018-03-06)
 
 #### New

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlasclient",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "native_version": "v3.7.2",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -164,6 +164,9 @@ IdPtr idFromValue(const Nan::FunctionCallbackInfo<v8::Value>& info, int argc) {
         "tags");
   }
   std::string name{*Nan::Utf8String(info[0])};
+  if (name.empty()) {
+    Nan::ThrowError("Cannot create a metric with an empty name");
+  }
 
   Tags tags;
   if (argc == 2) {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -303,6 +303,14 @@ describe('atlas extension', () => {
     assert.throw(fn, /invalidKey/);
   });
 
+  it('should make sure metrics have a name', () => {
+    atlas.setDevMode(false);
+    const noName = () => {
+      atlas.counter('');
+    };
+    assert.throw(noName, /empty/);
+  });
+
   it('should validate metrics when in dev mode', () => {
     atlas.setDevMode(true);
     const noName = () => {


### PR DESCRIPTION
Metrics must have a non-empty name. Otherwise we throw at creation time,
even when dev-mode is false.