### PR TITLE
Do not throw errors in prod

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 1.22.0 (2018-03-21)
+
+#### Fix
+
+* Make sure we do not throw errors in production
+
 ## 1.21.1 (2018-03-09)
 
 #### Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlasclient",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "native_version": "v3.7.2",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",

--- a/src/functions.cc
+++ b/src/functions.cc
@@ -90,6 +90,7 @@ NAN_METHOD(config) {
 }
 
 static Measurement getMeasurement(v8::Isolate* isolate, Local<v8::Value> v) {
+  std::string err_msg;
   auto o = v->ToObject();
   auto nameVal =
       Nan::Get(o, Nan::New("name").ToLocalChecked()).ToLocalChecked();
@@ -105,7 +106,7 @@ static Measurement getMeasurement(v8::Isolate* isolate, Local<v8::Value> v) {
                      .ToLocalChecked()
                      ->ToObject();
   Tags tags;
-  tagsFromObject(isolate, tagsObj, &tags);
+  tagsFromObject(isolate, tagsObj, &tags, &err_msg);
 
   auto id = atlas_registry.CreateId(name, tags);
   return Measurement{id, timestamp, value};

--- a/src/start_stop.cc
+++ b/src/start_stop.cc
@@ -232,9 +232,10 @@ NAN_METHOD(start) {
 
     auto maybe_runtime_tags = options->Get(context, runtimeTagsKey);
     if (!maybe_runtime_tags.IsEmpty()) {
+      std::string err_msg;
       tagsFromObject(isolate,
                      maybe_runtime_tags.ToLocalChecked().As<v8::Object>(),
-                     &runtime_tags);
+                     &runtime_tags, &err_msg);
     }
 
     auto maybeRuntimeMetrics = options->Get(context, runtimeMetricsKey);

--- a/src/utils.h
+++ b/src/utils.h
@@ -4,7 +4,7 @@
 #include <nan.h>
 
 bool tagsFromObject(v8::Isolate* isolate, const v8::Local<v8::Object>& object,
-                    atlas::meter::Tags* tags);
+                    atlas::meter::Tags* tags, std::string* err_msg);
 
 atlas::meter::IdPtr idFromValue(
     const Nan::FunctionCallbackInfo<v8::Value>& info, int argc);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -281,36 +281,6 @@ describe('atlas extension', () => {
     assert.isAtLeast(d.measurements.length, 2);
   });
 
-  it('should throw an error when creating meters with no name', () => {
-    assert.throw(atlas.counter, /name/);
-  });
-
-  it('should throw an error when creating meters with empty key tags', () => {
-    const fn = () => {
-      atlas.counter('error', {
-        '': 'value'
-      });
-    };
-    assert.throw(fn, /empty key/);
-  });
-
-  it('should throw an error when creating meters with empty value tags', () => {
-    const fn = () => {
-      atlas.counter('error', {
-        invalidKey: ''
-      });
-    };
-    assert.throw(fn, /invalidKey/);
-  });
-
-  it('should make sure metrics have a name', () => {
-    atlas.setDevMode(false);
-    const noName = () => {
-      atlas.counter('');
-    };
-    assert.throw(noName, /empty/);
-  });
-
   it('should validate metrics when in dev mode', () => {
     atlas.setDevMode(true);
     const noName = () => {
@@ -344,6 +314,47 @@ describe('atlas extension', () => {
       atlas.counter('foo', {'atlas.test': 'foo'});
     };
     assert.throw(reserved, /reserved namespace/);
+
+  });
+
+  it('should not throw when in prod', () => {
+    atlas.setDevMode(false);
+
+    // empty name
+    atlas.counter('');
+
+    // empty key
+    atlas.counter('foo', { '': undefined });
+
+    // empty val
+    atlas.counter('foo', { 'k': '' });
+
+    const invalidTagKey = () => {
+      const tags = {};
+      tags['a'.repeat(70)] = 'v';
+      atlas.timer('foo', tags);
+    };
+    invalidTagKey();
+
+    const invalidTagVal = () => {
+      atlas.timer('foo', {k: 'a'.repeat(160)});
+    };
+    invalidTagVal();
+
+    const tooManyTags = () => {
+      const tags = {};
+
+      for (let i = 0; i < 22; ++i) {
+        tags[i] = 'v';
+      }
+      atlas.counter('f', tags);
+    };
+    tooManyTags();
+
+    const reserved = () => {
+      atlas.counter('foo', {'atlas.test': 'foo'});
+    };
+    reserved();
 
   });
 });


### PR DESCRIPTION
Change the behavior so errors are never thrown when creating metrics
in production. Only throw in `devMode`