### PR TITLE
Upgrade to libatlasclient 3.7.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## 1.22.1 (2018-03-26)
+
+#### Fix
+
+* Uses native client 3.7.3 which removes the use of sleep allowing the client
+  to be started and stopped quickly (in integration tests for example), plus
+  some other bug fixes.
+
 ## 1.22.0 (2018-03-21)
 
 #### Fix

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlasclient",
-  "version": "1.22.0",
-  "native_version": "v3.7.2",
+  "version": "1.22.1",
+  "native_version": "v3.7.3",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -327,7 +327,7 @@ describe('atlas extension', () => {
     atlas.counter('foo', { '': undefined });
 
     // empty val
-    atlas.counter('foo', { 'k': '' });
+    atlas.counter('foo', { k: '' });
 
     const invalidTagKey = () => {
       const tags = {};


### PR DESCRIPTION
* No sleep before sending the first batch of metrics, plus a fix to
avoid reading uninitialized memory