### PR TITLE
Update to native client v0.4.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 1.23.1 (2018-05-16)
+
+#### Update
+
+* Uses native client 0.4.2 (new versioning) which expires meters from the
+  registry, and includes some minor performance improvements.
+ 
 ## 1.23.0 (2018-05-04)
 
 #### Update

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlasclient",
-  "version": "1.23.0",
-  "native_version": "v4.0.1",
+  "version": "1.23.1",
+  "native_version": "v0.4.2",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {


### PR DESCRIPTION
New versioning for the native client, expires unused meters from the
registry.