### PR TITLE
Add analyzeId helper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## 1.23.2 (2018-05-21)
+
+#### Update
+
+* Uses native client 0.4.4 and its `AnalyzeTags` helper function by exposing 
+  an `analyzeId()` function that takes a name, and tags to keep the interface
+  consistent with the meter functions.
+ 
 ## 1.23.1 (2018-05-16)
 
 #### Update

--- a/index.js
+++ b/index.js
@@ -107,6 +107,10 @@ function devMode(enabled) {
   atlas.setDevMode(enabled);
 }
 
+function analyzeId(name, tags) {
+  return atlas.analyzeId(name, tags);
+}
+
 let scope = function(commonTags) {
   let bucketArgs = function(name) {
     let tags, bucketFunction;
@@ -127,6 +131,7 @@ let scope = function(commonTags) {
     stop: stopAtlas,
     setDevMode: devMode,
     getDebugInfo: debugInfo,
+    analyzeId: analyzeId,
     counter: (name, tags) => atlas.counter(
       name, Object.assign({}, commonTags, tags)),
     dcounter: (name, tags) => atlas.dcounter(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlasclient",
-  "version": "1.23.1",
-  "native_version": "v0.4.3",
+  "version": "1.23.2",
+  "native_version": "v0.4.4",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {

--- a/src/atlas.cc
+++ b/src/atlas.cc
@@ -78,6 +78,9 @@ NAN_MODULE_INIT(InitAll) {
   Set(target, New("setDevMode").ToLocalChecked(),
       GetFunction(New<FunctionTemplate>(set_dev_mode)).ToLocalChecked());
 
+  Set(target, New("analyzeId").ToLocalChecked(),
+      GetFunction(New<FunctionTemplate>(analyze_id)).ToLocalChecked());
+
   JsCounter::Init(target);
   JsDCounter::Init(target);
   JsIntervalCounter::Init(target);

--- a/src/functions.h
+++ b/src/functions.h
@@ -13,6 +13,9 @@
 // enable/disable development mode
 NAN_METHOD(set_dev_mode);
 
+// perform validation checks on name, tags
+NAN_METHOD(analyze_id);
+
 // get an array of measurements intended for the main publish pipeline
 NAN_METHOD(measurements);
 //

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1,129 +1,60 @@
 #include "utils.h"
 #include "atlas.h"
+#include <atlas/meter/validation.h>
 #include <iostream>
 #include <sstream>
 #include <unordered_set>
 
+using atlas::meter::AnalyzeTags;
 using atlas::meter::IdPtr;
 using atlas::meter::Tags;
+using atlas::meter::ValidationIssue;
 using atlas::util::intern_str;
 using atlas::util::StartsWith;
 using atlas::util::StrRef;
 
 bool dev_mode = false;
 
-static bool empty_or_null(StrRef r) { return r.is_null() || r.length() == 0; }
-
-static bool is_key_restricted(StrRef k) {
-  return StartsWith(k, "nf.") || StartsWith(k, "atlas.");
-}
-
-static std::unordered_set<StrRef> kValidNfTags = {
-    intern_str("nf.node"),          intern_str("nf.cluster"),
-    intern_str("nf.app"),           intern_str("nf.asg"),
-    intern_str("nf.stack"),         intern_str("nf.ami"),
-    intern_str("nf.vmtype"),        intern_str("nf.zone"),
-    intern_str("nf.region"),        intern_str("nf.account"),
-    intern_str("nf.country"),       intern_str("nf.task"),
-    intern_str("nf.country.rollup")};
-
-static auto kDsType = intern_str("atlas.dstype");
-static auto kLegacy = intern_str("atlas.legacy");
-static auto kNameRef = intern_str("name");
-
-static bool is_user_key_invalid(StrRef k) noexcept {
-  if (StartsWith(k, "atlas.")) {
-    return k != kDsType && k != kLegacy;
-  }
-
-  if (StartsWith(k, "nf.")) {
-    return kValidNfTags.find(k) == kValidNfTags.end();
-  }
-
-  return false;
-}
-
-static constexpr size_t MAX_KEY_LENGTH = 60;
-static constexpr size_t MAX_VAL_LENGTH = 120;
-static constexpr size_t MAX_USER_TAGS = 20;
-static constexpr size_t MAX_NAME_LENGTH = 255;
-static void throw_if_invalid(const std::string& name, const Tags& tags) {
-  std::ostringstream name_err;
-  auto invalid_name = false;
-  if (name.empty()) {
-    name_err << "Name is required, cannot be empty\n";
-    invalid_name = true;
-  } else if (name.length() > MAX_NAME_LENGTH) {
-    name_err << "Name '" << name
-             << "' exceeds length limits. Length=" << name.length() << " > "
-             << MAX_NAME_LENGTH << "\n";
-    invalid_name = true;
-  }
-
-  auto invalid_tags = false;
-  std::ostringstream tag_errors;
-  size_t user_tags = 0;
+std::ostream& operator<<(std::ostream& os, const Tags& tags) {
+  os << '{';
+  auto first = true;
   for (const auto& kv : tags) {
-    const auto& k_ref = kv.first;
-    const auto& v_ref = kv.second;
-
-    if (empty_or_null(k_ref) || empty_or_null(v_ref)) {
-      invalid_tags = true;
-      tag_errors << "A tag cannot have an empty key or value\n";
-      continue;
-    }
-
-    auto k_length = k_ref.length();
-    auto v_length = v_ref.length();
-    if (k_length > MAX_KEY_LENGTH || v_length > MAX_VAL_LENGTH) {
-      invalid_tags = true;
-      tag_errors << "Tag " << k_ref.get() << "=" << v_ref.get()
-                 << " exceeds length limits. ";
-      if (k_length > MAX_KEY_LENGTH) {
-        tag_errors << "Key length=" << k_length << " > " << MAX_KEY_LENGTH;
-      }
-      if (v_length > MAX_VAL_LENGTH) {
-        if (k_length > MAX_KEY_LENGTH) {
-          tag_errors << ", ";
-        }
-        tag_errors << "Value length=" << v_length << " > " << MAX_VAL_LENGTH;
-      }
-      tag_errors << '\n';
-    }
-
-    if (!is_key_restricted(k_ref)) {
-      ++user_tags;
-    }
-
-    if (is_user_key_invalid(k_ref)) {
-      invalid_tags = true;
-      tag_errors << "Tag key " << k_ref.get()
-                 << " is using a reserved namespace\n";
-    }
-  }
-
-  if (user_tags > MAX_USER_TAGS) {
-    invalid_tags = true;
-    tag_errors << "Too many user tags. There is a " << MAX_USER_TAGS
-               << " user tags limit. Detected user tags = " << user_tags
-               << '\n';
-  }
-
-  if (invalid_name || invalid_tags) {
-    std::string err_msg;
-    if (invalid_name) {
-      err_msg = name_err.str();
+    if (first) {
+      first = false;
     } else {
-      err_msg = "Metric with name='" + name + "' contains invalid tags\n";
+      os << ", ";
+    }
+    os << kv.first.get() << '=' << kv.second.get();
+  }
+  os << '}';
+  return os;
+}
+
+static void throw_if_invalid(const std::string& name, const Tags& tags) {
+  Tags to_check{tags};
+  to_check.add("name", name.c_str());
+
+  auto res = atlas::meter::AnalyzeTags(to_check);
+  // no warnings or errors found
+  if (res.empty()) {
+    return;
+  }
+
+  auto errs = 0;
+  std::ostringstream err_msg;
+  err_msg << "[name:'" << name << "', tags:" << tags << "]:\n";
+  for (const auto& issue : res) {
+    if (issue.level == ValidationIssue::Level::ERROR) {
+      ++errs;
     }
 
-    if (invalid_tags) {
-      err_msg += tag_errors.str();
-    }
+    err_msg << '\t' << issue.ToString() << '\n';
+  }
 
-    // remove the trailing newline
-    err_msg[err_msg.length() - 1] = '\0';
-    Nan::ThrowError(err_msg.c_str());
+  // do not throw if warnings only
+  if (errs > 0) {
+    auto err = err_msg.str();
+    Nan::ThrowError(err.c_str());
   }
 }
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -357,4 +357,57 @@ describe('atlas extension', () => {
     reserved();
 
   });
+
+  it('should validate metric IDs', () => {
+    const noName = atlas.analyzeId('');
+    assert.equal(noName.length, 1);
+    assert.match(noName[0].ERROR, /'name'/); // complains about 'name'
+
+    // empty key
+    const emptyKey = atlas.analyzeId('foo', { '': undefined });
+    assert.equal(emptyKey.length, 1);
+    assert.match(emptyKey[0].ERROR, /empty/i);
+
+    // empty val
+    const emptyVal = atlas.analyzeId('foo', { k: '' });
+    assert.equal(emptyVal.length, 1);
+    assert.match(emptyVal[0].ERROR, /key 'k' cannot be empty/i);
+
+    {
+      const key = 'a'.repeat(70);
+      const tags = {};
+      tags[key] = 'v';
+      const keyTooLong = atlas.analyzeId('foo', tags);
+      assert.equal(keyTooLong.length, 1);
+      assert.match(keyTooLong[0].ERROR, /aaaa' exceeds/i);
+    }
+
+    const valTooLong = atlas.analyzeId('foo', {k: 'a'.repeat(160)});
+    assert.equal(valTooLong.length, 1);
+    assert.match(valTooLong[0].ERROR, /aaa' for key 'k' exceeds/i);
+
+    {
+      const tags = {};
+
+      for (let i = 0; i < 22; ++i) {
+        tags[i] = 'v';
+      }
+      const tooManyTags = atlas.analyzeId('f', tags);
+      assert.equal(tooManyTags.length, 1);
+      // 22 tags + name > 20
+      assert.match(tooManyTags[0].ERROR, /too many user tags.*23/i);
+    };
+
+    const reserved = atlas.analyzeId('foo', {'atlas.test': 'foo'});
+    assert.equal(reserved.length, 1);
+    assert.match(reserved[0].ERROR, /reserved namespace/i);
+
+    // warning only
+    const warnings = atlas.analyzeId('foo ', {'bar#1': 'val%2'});
+    assert.equal(warnings.length, 3);
+
+    for (const issue of warnings) {
+      assert.match(issue.WARN, /encoded as/);
+    }
+  });
 });


### PR DESCRIPTION
Uses native client 0.4.4 and its `AnalyzeTags` helper function by
exposing an `analyzeId()` function that takes a name, and tags to keep
the interface consistent with the meter functions.