### PR TITLE
Rename analyzeId to validateNameAndTags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,9 @@
-## 1.23.2 (2018-05-21)
+## 1.23.2 (2018-05-22)
 
 #### Update
 
 * Uses native client 0.4.4 and its `AnalyzeTags` helper function by exposing 
-  an `analyzeId()` function that takes a name, and tags to keep the interface
+  a `validateNameAndTags()` function that takes a name, and tags to keep the interface
   consistent with the meter functions.
  
 ## 1.23.1 (2018-05-16)

--- a/index.js
+++ b/index.js
@@ -107,8 +107,8 @@ function devMode(enabled) {
   atlas.setDevMode(enabled);
 }
 
-function analyzeId(name, tags) {
-  return atlas.analyzeId(name, tags);
+function validateNameAndTags(name, tags) {
+  return atlas.validateNameAndTags(name, tags);
 }
 
 let scope = function(commonTags) {
@@ -131,7 +131,7 @@ let scope = function(commonTags) {
     stop: stopAtlas,
     setDevMode: devMode,
     getDebugInfo: debugInfo,
-    analyzeId: analyzeId,
+    validateNameAndTags: validateNameAndTags,
     counter: (name, tags) => atlas.counter(
       name, Object.assign({}, commonTags, tags)),
     dcounter: (name, tags) => atlas.dcounter(

--- a/src/atlas.cc
+++ b/src/atlas.cc
@@ -78,8 +78,8 @@ NAN_MODULE_INIT(InitAll) {
   Set(target, New("setDevMode").ToLocalChecked(),
       GetFunction(New<FunctionTemplate>(set_dev_mode)).ToLocalChecked());
 
-  Set(target, New("analyzeId").ToLocalChecked(),
-      GetFunction(New<FunctionTemplate>(analyze_id)).ToLocalChecked());
+  Set(target, New("validateNameAndTags").ToLocalChecked(),
+      GetFunction(New<FunctionTemplate>(validate_name_tags)).ToLocalChecked());
 
   JsCounter::Init(target);
   JsDCounter::Init(target);

--- a/src/functions.cc
+++ b/src/functions.cc
@@ -44,7 +44,7 @@ static void addTags(v8::Isolate* isolate, const v8::Local<v8::Object>& object,
   }
 }
 
-NAN_METHOD(analyze_id) {
+NAN_METHOD(validate_name_tags) {
   const char* err_msg = nullptr;
   std::string name;
   ValidationIssues res;

--- a/src/functions.h
+++ b/src/functions.h
@@ -14,7 +14,7 @@
 NAN_METHOD(set_dev_mode);
 
 // perform validation checks on name, tags
-NAN_METHOD(analyze_id);
+NAN_METHOD(validate_name_tags);
 
 // get an array of measurements intended for the main publish pipeline
 NAN_METHOD(measurements);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -359,17 +359,17 @@ describe('atlas extension', () => {
   });
 
   it('should validate metric IDs', () => {
-    const noName = atlas.analyzeId('');
+    const noName = atlas.validateNameAndTags('');
     assert.equal(noName.length, 1);
     assert.match(noName[0].ERROR, /'name'/); // complains about 'name'
 
     // empty key
-    const emptyKey = atlas.analyzeId('foo', { '': undefined });
+    const emptyKey = atlas.validateNameAndTags('foo', { '': undefined });
     assert.equal(emptyKey.length, 1);
     assert.match(emptyKey[0].ERROR, /empty/i);
 
     // empty val
-    const emptyVal = atlas.analyzeId('foo', { k: '' });
+    const emptyVal = atlas.validateNameAndTags('foo', { k: '' });
     assert.equal(emptyVal.length, 1);
     assert.match(emptyVal[0].ERROR, /key 'k' cannot be empty/i);
 
@@ -377,12 +377,12 @@ describe('atlas extension', () => {
       const key = 'a'.repeat(70);
       const tags = {};
       tags[key] = 'v';
-      const keyTooLong = atlas.analyzeId('foo', tags);
+      const keyTooLong = atlas.validateNameAndTags('foo', tags);
       assert.equal(keyTooLong.length, 1);
       assert.match(keyTooLong[0].ERROR, /aaaa' exceeds/i);
     }
 
-    const valTooLong = atlas.analyzeId('foo', {k: 'a'.repeat(160)});
+    const valTooLong = atlas.validateNameAndTags('foo', {k: 'a'.repeat(160)});
     assert.equal(valTooLong.length, 1);
     assert.match(valTooLong[0].ERROR, /aaa' for key 'k' exceeds/i);
 
@@ -392,18 +392,18 @@ describe('atlas extension', () => {
       for (let i = 0; i < 22; ++i) {
         tags[i] = 'v';
       }
-      const tooManyTags = atlas.analyzeId('f', tags);
+      const tooManyTags = atlas.validateNameAndTags('f', tags);
       assert.equal(tooManyTags.length, 1);
       // 22 tags + name > 20
       assert.match(tooManyTags[0].ERROR, /too many user tags.*23/i);
     }
 
-    const reserved = atlas.analyzeId('foo', {'atlas.test': 'foo'});
+    const reserved = atlas.validateNameAndTags('foo', {'atlas.test': 'foo'});
     assert.equal(reserved.length, 1);
     assert.match(reserved[0].ERROR, /reserved namespace/i);
 
     // warning only
-    const warnings = atlas.analyzeId('foo ', {'bar#1': 'val%2'});
+    const warnings = atlas.validateNameAndTags('foo ', {'bar#1': 'val%2'});
     assert.equal(warnings.length, 3);
 
     for (const issue of warnings) {


### PR DESCRIPTION
It's a more descriptive name. The node bindings don't expose the concept
of an `Id` so the previous name didn't make a lot of sense.