### PR TITLE
output clearer error message on runtime linking error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,31 @@
 'use strict';
 
-let atlas = require('bindings')('atlas');
+let atlas;
+const chalk = require('chalk');
+
+// See https://github.com/Netflix-Skunkworks/atlas-node-client/issues/25 for
+// more details.
+try {
+  atlas = require('bindings')('atlas');
+} catch (loadErr) {
+  if (loadErr.message &&
+      /undefined symbol: [_\w]+atlas[_\w]+/.test(loadErr.message)) {
+    console.error(chalk.red('!!! Incompatible atlasclient dependencies ' +
+      'detected! !!!'));
+    console.error('');
+    console.error(chalk.red('This is likely the result of loading two ' +
+      'incompatible versions of the atlasclient module.'));
+    console.error(chalk.red('Make sure all your atlasclient dependencies ' +
+      'specify the same version, or even better, that only your toplevel ' +
+      'application requires the atlasclient module'));
+    console.error('');
+    console.error(chalk.red('!!! Incompatible atlasclient dependencies ' +
+      'detected! !!!'));
+    console.error('');
+  }
+  throw loadErr;
+}
+
 let updateInterval = 30000;
 let nodeMetrics;
 

--- a/package.json
+++ b/package.json
@@ -40,9 +40,10 @@
     "host": "https://atlasclient.us-east-1.iepprod.netflix.net.s3-us-east-1.amazonaws.com"
   },
   "dependencies": {
-    "node-pre-gyp": "0.6.x",
-    "nan": "^2.6.2",
     "bindings": "^1.2.1",
+    "chalk": "^2.4.1",
+    "nan": "^2.6.2",
+    "node-pre-gyp": "0.6.x",
     "pkginfo": "^0.4.0"
   }
 }


### PR DESCRIPTION
This fixes #25. A few comments:

1. It doesn't have any test: we could probably add a test for this using LD_LIBRARY_PATH, but I'd rather validate that the overall idea with this change is valid before doing so. However, I tested this PR by using those changes within https://github.com/NetflixUI/test-atlas-client-conflict, which reproduces the issue, and I was able to verify that it works as expected.

2. It adds a dependency on chalk to output the custom error message in read, with the intention to make it more obvious to users when the message is outputted directly to a terminal. That adds ~50KBs to the overall dependencies size. We could probably output the proper terminal escape sequence instead.

3. The regexp used could be a little less specific and could just be `/undefined symbol:/`. It seems it'd be better to err on the side of having false positives than false negatives.