### PR TITLE
Bump version to 1.23.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 1.23.4 (2018-07-27)
+
+#### Fix
+
+* Output a better error message when failing to load the binary module
+
 ## 1.23.3 (2018-06-29)
 
 #### Update

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlasclient",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "native_version": "v0.4.5",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",


### PR DESCRIPTION
Updating changelog to reflect the only change is the better error
message when failing to load a binary incompatible lib