### PR TITLE
Update atlas native client to 0.5.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 1.23.7 (2018-10-09)
+
+#### Update
+
+* Uses native client 0.5.3 to use step numbers in the consolidation registry. 
+  This allows it to correctly attribute the update to a given step.
+
 ## 1.23.6 (2018-10-04)
 
 #### Update

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlasclient",
-  "version": "1.23.6",
-  "native_version": "v0.5.2",
+  "version": "1.23.7",
+  "native_version": "v0.5.3",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {


### PR DESCRIPTION
To use step numbers in the consolidation registry.  That is required to
properly attribute the activity to a given interval.