### PR TITLE
Update native-client used

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 1.23.8 (2018-10-11)
+
+#### Update
+
+* native-client 0.5.4 for fixes around attributing increments to the correct
+  bucket
+ 
 ## 1.23.7 (2018-10-09)
 
 #### Update

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlasclient",
-  "version": "1.23.7",
-  "native_version": "v0.5.3",
+  "version": "1.23.8",
+  "native_version": "v0.5.4",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {


### PR DESCRIPTION
For fixes around the timestamp used when updating the consolidated
registry