### PR TITLE
Update atlas-native-client: fix validation counter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 1.23.9 (2019-03-13)
+
+#### Update
+
+* native-client 0.5.6 for fixes around validation errors
+
 ## 1.23.8 (2018-10-11)
 
 #### Update

--- a/Makefile
+++ b/Makefile
@@ -107,12 +107,8 @@ nsp: node_modules $(ALL_FILES)
 .PHONY: prepush
 prepush: node_modules lint codestyle coverage nsp 
 
-.PHONY: clean-release
-clean-release:
-	@rm -rf $(ROOT)/build/Release
-
 .PHONY: package
-package: clean-release node_modules test lint codestyle
+package: node_modules test lint codestyle
 	@$(PREGYP) package
 
 .PHONY: publish

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlasclient",
-  "version": "1.23.8",
-  "native_version": "v0.5.4",
+  "version": "1.23.9",
+  "native_version": "v0.5.6",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {


### PR DESCRIPTION
Use the native-client 0.5.6 which fixes the number of validation error
reported.  Also remove the clean-release build target since that might
be used incorrectly by some users