### PR TITLE
Update native-client used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: node_js
 node_js:
   - "6"
   - "8"
-  - "9"
 os:
-  - "osx"
-
-osx_image: xcode9.1
+  - "linux"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
   - "6"
   - "8"
+  - "9"
 os:
-  - "linux"
+  - "osx"
+
+osx_image: xcode10.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 1.23.10 (2019-04-22)
+
+* native-client 0.5.7 fixes honoring the env var for disabled file
+
 ## 1.23.9 (2019-03-13)
 
 #### Update

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlasclient",
-  "version": "1.23.9",
-  "native_version": "v0.5.6",
+  "version": "1.23.10",
+  "native_version": "v0.5.7",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {


### PR DESCRIPTION
Use native-client v0.57.0 to honor the environment variable used for the atlas disabled file