### PR TITLE
Update dependendencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "9"
+  - "10"
 os:
   - "osx"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
-  - "9"
 os:
   - "osx"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8"
+  - "9"
 os:
   - "osx"
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlasclient",
-  "version": "1.23.10",
-  "native_version": "v0.5.7",
+  "version": "1.23.11",
+  "native_version": "v4.0.2",
   "main": "index.js",
   "homepage": "https://stash.corp.netflix.com/projects/CLDMTA/repos/atlas-node-client",
   "repository": {
@@ -17,21 +17,20 @@
     "codestyle-fix": "make codestyle-fix",
     "install": "node-pre-gyp install --fallback-to-build",
     "postinstall": "make post-install",
-    "test": "mocha"
+    "test": "mocha --exit"
   },
   "bundleDependencies": [
     "node-pre-gyp"
   ],
   "devDependencies": {
-    "chai": "^3.5.0",
-    "coveralls": "^2.11.9",
-    "eslint": "^2.10.2",
-    "istanbul": "^0.4.3",
-    "jscs": "^2.11.0",
-    "mocha": "^3.1.0",
+    "chai": "^4.2.0",
+    "coveralls": "^3.1.0",
+    "eslint": "^7.2.0",
+    "istanbul": "^0.4.5",
+    "jscs": "^3.0.7",
+    "mocha": "^8.0.1",
     "node-gyp": "^3.6.0",
-    "nsp": "^2.4.0",
-    "sinon": "^1.17.6"
+    "sinon": "^9.0.2"
   },
   "binary": {
     "module_name": "atlas",
@@ -40,9 +39,9 @@
     "host": "https://atlasclient.us-east-1.iepprod.netflix.net.s3-us-east-1.amazonaws.com"
   },
   "dependencies": {
-    "bindings": "^1.2.1",
-    "nan": "^2.6.2",
-    "node-pre-gyp": "0.6.x",
-    "pkginfo": "^0.4.0"
+    "bindings": "^1.5.0",
+    "nan": "^2.14.1",
+    "node-pre-gyp": "^0.15.0",
+    "pkginfo": "^0.4.1"
   }
 }

--- a/scripts/install-lib-from-gh.sh
+++ b/scripts/install-lib-from-gh.sh
@@ -13,14 +13,14 @@ if [ $# = 0 ] ; then
 fi
 NATIVE_CLIENT_VERSION=$1
 
-rm -rf nc
-mkdir nc
+#rm -rf nc
+mkdir -p nc
 cd nc
 git init 
 git remote add origin https://github.com/Netflix-Skunkworks/atlas-native-client.git
 git fetch origin $NATIVE_CLIENT_VERSION
 git reset --hard FETCH_HEAD
-mkdir build root
+mkdir -p build root
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=/ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 make -j8 

--- a/scripts/install-lib-from-gh.sh
+++ b/scripts/install-lib-from-gh.sh
@@ -13,7 +13,7 @@ if [ $# = 0 ] ; then
 fi
 NATIVE_CLIENT_VERSION=$1
 
-#rm -rf nc
+rm -rf nc
 mkdir -p nc
 cd nc
 git init 

--- a/scripts/install-lib.js
+++ b/scripts/install-lib.js
@@ -5,14 +5,16 @@ const read = require('fs').readFileSync;
 const pkgJson = JSON.parse(read('package.json'));
 const cmd = 'sh ./scripts/install-lib-from-gh.sh ' + pkgJson.native_version;
 
-const child = exec(cmd);
-child.stdout.on('data', function(data) {
-  process.stdout.write(data);
+exec(cmd, (error, stdout, stderr) => {
+  if (error) {
+    throw error;
+  }
+
+  if (stderr) {
+    process.stderr.write('\x1b[31m' + stderr + '\x1b[0m');
+  }
+  if (stdout) {
+    process.stdout.write(stdout);
+  }
 });
-
-child.stderr.on('data', function(data) {
-  process.stderr.write('\x1b[31m' + data + '\x1b[0m');
-});
-
-
 


### PR DESCRIPTION
In particular update atlas-native-client to 4.0.2 to fix compilation
warnings on newer versions of clang, and update node-pre-gyp which has a
dependency on a vulnerable version of tar.